### PR TITLE
bugfix for #565

### DIFF
--- a/src/N98/Magento/Command/ConfigurationLoader.php
+++ b/src/N98/Magento/Command/ConfigurationLoader.php
@@ -119,7 +119,7 @@ class ConfigurationLoader
 
     /**
      * @param string $magentoRootFolder
-     * @param bool   $loadExternalConfig
+     * @param bool $loadExternalConfig
      * @param string $magerunStopFileFolder
      */
     public function loadStageTwo($magentoRootFolder, $loadExternalConfig = true, $magerunStopFileFolder = '')
@@ -202,7 +202,7 @@ class ConfigurationLoader
     /**
      * Load config from all installed bundles
      *
-     * @param array  $config
+     * @param array $config
      * @param string $magentoRootFolder
      *
      * @return array
@@ -213,11 +213,9 @@ class ConfigurationLoader
             $this->_pluginConfig = array();
             $moduleBaseFolders = array();
             if (OperatingSystem::isWindows()) {
-                $config['plugin']['folders'][] = getenv('WINDIR') . '/n98-magerun/modules';
-                $config['plugin']['folders'][] = OperatingSystem::getHomeDir() . '/n98-magerun/modules';
-            } else {
-                $config['plugin']['folders'][] = OperatingSystem::getHomeDir() . '/.n98-magerun/modules';
+                $config['plugin']['folders'][] = getenv('WINDIR') . OperatingSystem::$magerunFolder . 'modules';
             }
+            $config['plugin']['folders'][] = OperatingSystem::getHomeDir() . OperatingSystem::$magerunFolder . 'modules';
             $config['plugin']['folders'][] = $magentoRootFolder . '/lib/n98-magerun/modules';
             foreach ($config['plugin']['folders'] as $folder) {
                 if (is_dir($folder)) {
@@ -256,7 +254,8 @@ class ConfigurationLoader
                     ->name($this->_customConfigFilename)
                     ->in($moduleBaseFolders);
 
-                foreach ($finder as $file) { /* @var $file \Symfony\Component\Finder\SplFileInfo */
+                foreach ($finder as $file) {
+                    /* @var $file \Symfony\Component\Finder\SplFileInfo */
                     $this->registerPluginConfigFile($magentoRootFolder, $file);
                 }
             }
@@ -268,8 +267,8 @@ class ConfigurationLoader
     }
 
     /**
-     * @param string                                $rawConfig
-     * @param string                                $magentoRootFolder
+     * @param string $rawConfig
+     * @param string $magentoRootFolder
      * @param \Symfony\Component\Finder\SplFileInfo $file
      *
      * @return string
@@ -278,7 +277,7 @@ class ConfigurationLoader
     {
         $replace = array(
             '%module%' => $file ? $file->getPath() : '',
-            '%root%'   => $magentoRootFolder,
+            '%root%' => $magentoRootFolder,
         );
 
         return str_replace(array_keys($replace), $replace, $rawConfig);
@@ -288,7 +287,7 @@ class ConfigurationLoader
     /**
      * Check if there is a user config file. ~/.n98-magerun.yaml
      *
-     * @param array  $config
+     * @param array $config
      * @param string $magentoRootFolder
      *
      * @return array
@@ -297,12 +296,9 @@ class ConfigurationLoader
     {
         if ($this->_userConfig == null) {
             $this->_userConfig = array();
-            $homeDirectory =  OperatingSystem::getHomeDir();
-            if (OperatingSystem::isWindows()) {
-                $personalConfigFile = $homeDirectory . DIRECTORY_SEPARATOR . $this->_customConfigFilename;
-            } else {
-                $personalConfigFile = $homeDirectory . DIRECTORY_SEPARATOR . '.' . $this->_customConfigFilename;
-            }
+            $homeDirectory = OperatingSystem::getHomeDir();
+
+            $personalConfigFile = $homeDirectory . DIRECTORY_SEPARATOR . '.' . $this->_customConfigFilename;
 
             if ($homeDirectory && file_exists($personalConfigFile)) {
                 $userConfig = $this->applyVariables(\file_get_contents($personalConfigFile), $magentoRootFolder, null);
@@ -365,7 +361,7 @@ class ConfigurationLoader
     /**
      * Loads a plugin config file and merges it to plugin config
      *
-     * @param string       $magentoRootFolder
+     * @param string $magentoRootFolder
      * @param SplFileInfo $file
      */
     protected function registerPluginConfigFile($magentoRootFolder, $file)

--- a/src/N98/Magento/Command/Script/Repository/ScriptLoader.php
+++ b/src/N98/Magento/Command/Script/Repository/ScriptLoader.php
@@ -29,17 +29,14 @@ class ScriptLoader
     protected $_scriptFolders = array();
 
     /**
-     * @param array  $scriptFolders
+     * @param array $scriptFolders
      * @param string $magentoRootFolder
      */
     public function __construct(array $scriptFolders, $magentoRootFolder = null)
     {
         $this->_magentoRootFolder = $magentoRootFolder;
-        if (OperatingSystem::isWindows()) {
-            $this->_homeScriptFolder = OperatingSystem::getHomeDir() . '/n98-magerun/scripts';
-        } else {
-            $this->_homeScriptFolder = OperatingSystem::getHomeDir() . '/.n98-magerun/scripts';
-        }
+
+        $this->_homeScriptFolder = OperatingSystem::getHomeDir() . OperatingSystem::$magerunFolder . 'scripts';
 
         $this->_scriptFolders = $scriptFolders;
         $this->_scriptFolders[] = $this->_homeScriptFolder;
@@ -48,7 +45,7 @@ class ScriptLoader
                 unset($this->_scriptFolders[$key]);
             }
         }
-        
+
         if (count($this->_scriptFolders)) {
             $this->findScripts();
         }
@@ -64,11 +61,12 @@ class ScriptLoader
             ->in($this->_scriptFolders);
 
         $this->_scriptFiles = array();
-        foreach ($finder as $file) { /* @var $file SplFileInfo */
+        foreach ($finder as $file) {
+            /* @var $file SplFileInfo */
             $this->_scriptFiles[$file->getFilename()] = array(
-                'fileinfo'    => $file,
+                'fileinfo' => $file,
                 'description' => $this->_readFirstLineOfFile($file->getPathname()),
-                'location'    => $this->_getLocation($file->getPathname()),
+                'location' => $this->_getLocation($file->getPathname()),
             );
         }
 

--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -7,6 +7,11 @@ class OperatingSystem
 
 
     /**
+     * @var string
+     */
+    public static $magerunFolder = '/.n98-magerun/';
+
+    /**
      * @var int
      */
     const UID_ROOT = 0;


### PR DESCRIPTION
fixed inconsistent n98-magerun folder and global configuration file on windows
the global n98-magerun folder and configuration file are now prefixed with a dot (.) on all platforms